### PR TITLE
fix: replace bower_components with CDN links

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -6,8 +6,7 @@
     <title>Old Town Alexandria Map</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
 
-    <!--Link to stylesheets associated with bower components-->
-    <link href="bower_components/bootstrap/dist/css/bootstrap.min.css" rel="stylesheet" />
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@3.3.6/dist/css/bootstrap.min.css" rel="stylesheet" />
 
     <!--Link to the concatenated stylesheet created by gulp-->
     <!--This concatendated stylesheet includes a Start Bootstrap theme available at http://startbootstrap.com/template-overviews/simple-sidebar/-->
@@ -85,10 +84,10 @@
     </div>
 
 
-    <script src="bower_components/jquery/jquery.min.js"></script>
-    <script src="bower_components/bootstrap/dist/js/bootstrap.min.js"></script>
-    <script src="bower_components/knockout/dist/knockout.js"></script>
-    <script src="bower_components/knockstrap/build/knockstrap.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/jquery@1.9.1/jquery.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@3.3.6/dist/js/bootstrap.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/knockout@3.4.0/build/output/knockout-latest.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/knockstrap@1.3.2/build/knockstrap.min.js"></script>
     <script src="js/scripts.js"></script>
 
     <script async defer src="https://maps.googleapis.com/maps/api/js?key=%%MAPS_API_KEY%%&callback=initMap" onerror="googleMapsError()"></script>


### PR DESCRIPTION
## Summary

- All four vendor libraries were 404ing on the deployed site because the build pipeline only outputs HTML/CSS/JS/images — it never copied `dist/bower_components/` to the `gh-pages` branch
- Fixes the live site by replacing the local `bower_components/` paths in `src/index.html` with jsDelivr CDN links, using the exact same versions that were previously vendored:
  - `bootstrap@3.3.6`
  - `jquery@1.9.1`
  - `knockout@3.4.0`
  - `knockstrap@1.3.2`
- No bower install step needed; `dist/` stays clean

## Test plan

- [x] Local build + static serve verified: map loads, markers render, navbar/sidebar correct, no JS errors (only benign `favicon.ico` 404)
- [ ] Confirm Actions deploy runs green after merge
- [ ] Verify live site at https://bushidocodes.github.io/oldtown-map/

🤖 Generated with [Claude Code](https://claude.com/claude-code)