### PR TITLE
fix: resolve three console warnings (loading=async, mobile-web-app-capable, favicon)

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -16,7 +16,7 @@
     <!--View http://blog.teamtreehouse.com/optimizing-mobile-web-apps-ios to understand these tags-->
     <!--Content based on tfausak's iOS8 web app shell located at https://gist.github.com/tfausak/2222823 -->
 
-    <!--Allow iOS to render as a Web App (outside of Safari)-->
+    <meta name="mobile-web-app-capable" content="yes">
     <meta name="apple-mobile-web-app-capable" content="yes">
 
     <!-- Make the app title different than the page title. -->
@@ -27,6 +27,7 @@
 
     <!--iOS icons-->
     <!--Optimized for iOS9 based on sizes at https://makeappicon.com/ios9icon-->
+    <link rel="icon" href="images/apple-touch-icon-120x120.png">
     <link rel="apple-touch-icon" href="images/apple-touch-icon-120x120.png">
     <link rel="apple-touch-icon" sizes="152x152" href="images/apple-touch-icon-152x152.png">
     <link rel="apple-touch-icon" sizes="120x120" href="images/apple-touch-icon-120x120.png">
@@ -90,7 +91,7 @@
     <script src="https://cdn.jsdelivr.net/npm/knockstrap@1.3.2/build/knockstrap.min.js"></script>
     <script src="js/scripts.js"></script>
 
-    <script async defer src="https://maps.googleapis.com/maps/api/js?key=%%MAPS_API_KEY%%&callback=initMap" onerror="googleMapsError()"></script>
+    <script async defer src="https://maps.googleapis.com/maps/api/js?key=%%MAPS_API_KEY%%&callback=initMap&loading=async" onerror="googleMapsError()"></script>
 
     <!-- Menu Toggle Script -->
     <script>


### PR DESCRIPTION
## Summary

Fixes three browser console warnings visible on the deployed site:

- **`loading=async` perf warning** — adds `&loading=async` to the Google Maps script URL; this is the parameter the Maps API checks for, distinct from the `async` HTML attribute
- **`apple-mobile-web-app-capable` deprecated** — adds the standard `<meta name="mobile-web-app-capable" content="yes">` alongside the Apple-specific one; both coexist fine
- **`favicon.ico` 404** — adds `<link rel="icon">` pointing at the existing `images/apple-touch-icon-120x120.png` so browsers don't make a failing request

## Not included

The `google.maps.Marker` deprecation warning requires migrating to `AdvancedMarkerElement`, which is tracked as a separate issue. That migration is non-trivial: `AdvancedMarkerElement` requires a `mapId`, and setting a `mapId` causes the inline `styles` (the custom dark map theme) to be silently ignored — styles must move to Google Cloud Console map styling instead. The bounce animation would also need to be reimplemented in CSS.

## Test plan

- [x] Local build + verify: 0 console errors, 0 non-Marker warnings
- [ ] Confirm Actions deploy runs green
- [ ] Verify favicon appears in browser tab on live site

🤖 Generated with [Claude Code](https://claude.com/claude-code)