### PR TITLE
fix: constrain InfoWindow image container to prevent off-screen overflow

### DIFF
--- a/src/js/app.js
+++ b/src/js/app.js
@@ -175,6 +175,8 @@ function generateInfoWindow(site, map, marker, delay) {
         container.appendChild(document.createElement('br'));
 
         var imagesContainer = document.createElement('div');
+        imagesContainer.style.maxHeight = '160px';
+        imagesContainer.style.overflowY = 'auto';
         container.appendChild(imagesContainer);
         pullImagesFromWikipedia(site, site.wikipediaID, imagesContainer);
     }
@@ -282,8 +284,8 @@ function pullImagesFromWikipedia(site, wikipediaID, imagesContainer) {
                 var img = document.createElement('img');
                 img.className = 'wiki-img img-circle';
                 img.src = imageUrl;
-                img.style.height = '20%';
-                img.style.width = '20%';
+                img.style.height = '80px';
+                img.style.width = '80px';
                 anchor.appendChild(img);
                 imagesContainer.appendChild(anchor);
             })


### PR DESCRIPTION
## Summary

Fixes #13 — Wikipedia images were pushing the top of the InfoWindow off-screen in Chrome and Edge.

**Root cause (two issues compounding):**
- Images used `height: 20% / width: 20%` which computes to nothing inside a Google Maps InfoWindow (no defined parent height), so images rendered at their full natural size.
- Images are appended asynchronously after the InfoWindow is already open. Google Maps pins the window's bottom to the marker and grows it upward, so large/many async images can push the top of the window above the viewport.

**Fix:**
- Changed image dimensions from `20%` to fixed `80px × 80px` squares.
- Added `max-height: 160px; overflow-y: auto` to the images container so the InfoWindow stays within a predictable, scrollable bounds no matter how many images load.

## Test plan

- [ ] Click a site marker that has a `wikipediaID` (e.g. one with Wikipedia images) and confirm the InfoWindow stays fully visible within the viewport after images load
- [ ] Confirm images are scrollable if more than ~2 rows load
- [ ] Verify the grayscale/hover CSS effect still applies to images
- [ ] Test in Chrome and Edge (browsers mentioned in the issue)

🤖 Generated with [Claude Code](https://claude.com/claude-code)