### PR TITLE
fix: upgrade jQuery 1.9.1→3.7.1 and Bootstrap 3.3.6→3.3.7 to close CVEs

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -16,8 +16,8 @@
     "tests"
   ],
   "dependencies": {
-    "jquery": "~1.9.1",
-    "bootstrap": "~3.3.6",
+    "jquery": "~3.7.1",
+    "bootstrap": "~3.3.7",
     "knockout": "^3.4.0",
     "knockstrap": "^1.3.2"
   }

--- a/src/index.html
+++ b/src/index.html
@@ -6,7 +6,7 @@
     <title>Old Town Alexandria Map</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
 
-    <link href="https://cdn.jsdelivr.net/npm/bootstrap@3.3.6/dist/css/bootstrap.min.css" rel="stylesheet" />
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@3.3.7/dist/css/bootstrap.min.css" rel="stylesheet" />
 
     <!--Link to the concatenated stylesheet created by gulp-->
     <!--This concatendated stylesheet includes a Start Bootstrap theme available at http://startbootstrap.com/template-overviews/simple-sidebar/-->
@@ -85,8 +85,8 @@
     </div>
 
 
-    <script src="https://cdn.jsdelivr.net/npm/jquery@1.9.1/jquery.min.js"></script>
-    <script src="https://cdn.jsdelivr.net/npm/bootstrap@3.3.6/dist/js/bootstrap.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/jquery@3.7.1/dist/jquery.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@3.3.7/dist/js/bootstrap.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/knockout@3.4.0/build/output/knockout-latest.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/knockstrap@1.3.2/build/knockstrap.min.js"></script>
     <script src="js/scripts.js"></script>


### PR DESCRIPTION
## Summary

- Bumps jQuery from 1.9.1 to 3.7.1, closing CVE-2015-9251, CVE-2019-11358, CVE-2020-11022, and CVE-2020-11023
- Bumps Bootstrap from 3.3.6 to 3.3.7 (the final Bootstrap 3.x release), which explicitly supports jQuery 3
- Updates `bower.json` pins to match the new CDN versions

All existing jQuery usage (`$.ajax`, `jQuery.grep`, `$(...)` selectors, `.toggleClass`, `.click`) is fully compatible with jQuery 3.x — no code changes required in `app.js` or the inline menu-toggle script.

Closes #18.

## Test plan

- [ ] Verify the page loads without console errors
- [ ] Confirm the sidebar menu toggle works (hamburger button)
- [ ] Select a site from the sidebar and confirm the map pans, marker bounces, and infoWindow opens
- [ ] Confirm Wikipedia images appear in the infoWindow for sites that have a `wikipediaID`
- [ ] Confirm dismissible alerts can be closed (Bootstrap `data-dismiss="alert"`)
- [ ] Search filters the sidebar list in real time

🤖 Generated with [Claude Code](https://claude.com/claude-code)