### PR TITLE
chore: upgrade Knockout CDN pin from 3.4.0 to 3.5.3

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -18,7 +18,7 @@
   "dependencies": {
     "jquery": "~3.7.1",
     "bootstrap": "~3.3.7",
-    "knockout": "^3.4.0",
+    "knockout": "^3.5.3",
     "knockstrap": "^1.3.2"
   }
 }

--- a/src/index.html
+++ b/src/index.html
@@ -91,7 +91,7 @@
 
     <script src="https://cdn.jsdelivr.net/npm/jquery@3.7.1/dist/jquery.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@3.3.7/dist/js/bootstrap.min.js"></script>
-    <script src="https://cdn.jsdelivr.net/npm/knockout@3.4.0/build/output/knockout-latest.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/knockout@3.5.3/build/output/knockout-latest.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/knockstrap@1.3.2/build/knockstrap.min.js"></script>
     <script src="js/scripts.js"></script>
 


### PR DESCRIPTION
## Summary

- Updates `src/index.html` CDN script tag from `knockout@3.4.0` to `knockout@3.5.3`
- Updates `bower.json` dependency pin to match (`^3.5.3`)

Knockout 3.5.3 is the current stable release (2023); 3.4.0 was from 2016 and has been EOL. This is a drop-in update with no HTML/JS changes required.

Closes #47

## Test plan

- [ ] App loads without console errors
- [ ] Sidebar filter and map markers render correctly
- [ ] Selecting a location opens the InfoWindow as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)