### PR TITLE
fix: guard against missing images key in Wikipedia API response

### DIFF
--- a/src/js/app.js
+++ b/src/js/app.js
@@ -234,8 +234,9 @@ function pullImagesFromWikipedia(site, wikipediaID, imagesContainer) {
         dataType: 'json',
         success: (function (data) {
             clearTimeout(wikiRequestTimeout);
-            for (var i = 0; i < data.query.pages[wikipediaID].images.length; i++) {
-                let imageName = data.query.pages[wikipediaID].images[i].title;
+            const images = data.query.pages[wikipediaID].images || [];
+            for (var i = 0; i < images.length; i++) {
+                let imageName = images[i].title;
                 let process = true;
                 if (imageName.indexOf('map') >= 0) process = false;
                 if (imageName.indexOf('Map') >= 0) process = false;


### PR DESCRIPTION
## Summary

- Adds `|| []` fallback at `src/js/app.js:237` before iterating Wikipedia images
- The Wikipedia `prop=images` API omits the `images` key entirely (rather than returning an empty array) when a page has no image files; the unguarded `.length` access threw an uncaught `TypeError`

Fixes #45

## Test plan

- [x] Mocked `$.ajax` to return a Wikipedia response with no `images` key — InfoWindow opens cleanly, no console errors
- [x] Normal image loading (Gadsby's Tavern Museum) still works after rebuild

🤖 Generated with [Claude Code](https://claude.com/claude-code)