### PR TITLE
fix: correct Black History Museum street address

### DIFF
--- a/src/js/app.js
+++ b/src/js/app.js
@@ -554,7 +554,7 @@ var ViewModel = function () {
         ),
         new Site(
             "Black History Museum",
-            "115 Prince St, Alexandria, VA 22314",
+            "902 Wythe St, Alexandria, VA 22314",
             38.812054,
             -77.048045,
             "Originally the segregated library for Alexandria's African American residents, the museum documents the " +


### PR DESCRIPTION
## Summary

- Fixes the `address` field for the Black History Museum entry in `src/js/app.js`
- Was incorrectly set to `115 Prince St` (Captain's Row's address); correct address is `902 Wythe St, Alexandria, VA 22314`
- Marker coordinates were already correct

Fixes #40

## Test plan

- [x] Black History Museum InfoWindow opens correctly
- [x] No console errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)