### PR TITLE
chore: update package.json URLs from spmcbride1201 to bushidocodes

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,12 +25,12 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/spmcbride1201/oldtown-map.git"
+    "url": "git+https://github.com/bushidocodes/oldtown-map.git"
   },
   "author": "",
   "license": "ISC",
   "bugs": {
-    "url": "https://github.com/spmcbride1201/oldtown-map/issues"
+    "url": "https://github.com/bushidocodes/oldtown-map/issues"
   },
-  "homepage": "https://github.com/spmcbride1201/oldtown-map#readme"
+  "homepage": "https://github.com/bushidocodes/oldtown-map#readme"
 }


### PR DESCRIPTION
## Summary

Updates three stale URL fields in `package.json` from the old `spmcbride1201` account to `bushidocodes`:

- `repository.url`
- `bugs.url`
- `homepage`

Fixes #39

🤖 Generated with [Claude Code](https://claude.com/claude-code)