### PR TITLE
fix: sync hamburger icon and overlay when selectSite closes sidebar

### DIFF
--- a/src/js/app.js
+++ b/src/js/app.js
@@ -612,6 +612,7 @@ var ViewModel = function () {
         clearInfoWindow();
         //Don't close the sidebar automatically if the window is so wide that the infowindow is fully visible on the visible portion of the map div
         if ($(window).width() < 1500) {
+            hamburger_cross();
             $("#wrapper").toggleClass("toggled");
         }
         map.panTo({ lat: site.lat, lng: site.lng });


### PR DESCRIPTION
## Summary

`selectSite()` closes the sidebar by toggling `#wrapper` but was skipping the `hamburger_cross()` call that syncs the button icon (`is-open` → `is-closed`) and hides the overlay. This left the dark overlay covering the map and the navbar still showing the X icon after a site was selected.

Fix: add `hamburger_cross()` before `toggleClass("toggled")` in the `width < 1500` branch, matching what the hamburger button and overlay click handlers already do.

Fixes #36

## Test plan

- [x] Reproduced the bug before the fix: after clicking a site, `btn.className` was `is-open`, `overlay` was `block`
- [x] After fix: `is-closed`, overlay `none`, wrapper not toggled — all correct
- [x] Ran two full open→click cycles; state stays in sync each time
- [x] No console errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)