### PR TITLE
fix: add error handlers to Wikipedia AJAX calls

### DIFF
--- a/src/js/app.js
+++ b/src/js/app.js
@@ -251,7 +251,10 @@ function pullImagesFromWikipedia(site, wikipediaID, imagesContainer) {
                 if (imageName.indexOf('btn') >= 0) process = false;
                 if (process) resolveWikipediaImageURL(imageName, imagesContainer);
             }
-        })
+        }),
+        error: function () {
+            clearTimeout(wikiRequestTimeout);
+        }
     });
 
     /* resolveWikipediaImageURL retrieves the image URL via JSON/CORS, validates it is an HTTPS
@@ -289,7 +292,8 @@ function pullImagesFromWikipedia(site, wikipediaID, imagesContainer) {
                 img.style.width = '80px';
                 anchor.appendChild(img);
                 imagesContainer.appendChild(anchor);
-            })
+            }),
+            error: function () {}
         });
     }
 


### PR DESCRIPTION
## Summary

Both `$.ajax` calls in `pullImagesFromWikipedia` were missing `error:` callbacks:

- **Outer call** (fetches image list): error handler now calls `clearTimeout(wikiRequestTimeout)`, preventing a non-200/CORS failure from triggering the "Wikipedia not responding" warning 3 seconds later
- **Inner call** (`resolveWikipediaImageURL`): adds a no-op error handler to silence unhandled jQuery AJAX errors on individual image URL resolution failures

The `images || []` guard from #45 is already present, so the TypeError mentioned in the issue is also covered.

Fixes #38

## Test plan

- [x] Patched `$.ajax` to force the `error` callback on all Wikipedia calls
- [x] Clicked Carlyle House (has Wikipedia ID), waited 4s — `#wikipedia-alert` remained `display: none` (timeout cleared correctly by error handler)
- [x] No console errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)