### PR TITLE
fix: add aria-expanded to hamburger button (WCAG 4.1.2)

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -62,7 +62,7 @@
 
         <!-- Navbar -->
         <nav class="navbar navbar-inverse">
-            <button type="button" class="hamburger is-closed navbar-btn navbar-left" id="menu-toggle" aria-label="Toggle navigation">
+            <button type="button" class="hamburger is-closed navbar-btn navbar-left" id="menu-toggle" aria-label="Toggle navigation" aria-expanded="false">
                 <span class="hamb-top"></span>
                 <span class="hamb-middle"></span>
                 <span class="hamb-bottom"></span>
@@ -108,6 +108,7 @@
             trigger.removeClass('is-open').addClass('is-closed');
             $('.overlay').hide();
         }
+        trigger.attr('aria-expanded', trigger.hasClass('is-open'));
     }
 
     $("#menu-toggle").click(function(e) {


### PR DESCRIPTION
## Summary

- Adds `aria-expanded="false"` to the `#menu-toggle` button in `src/index.html`
- Updates `hamburger_cross()` to call `trigger.attr('aria-expanded', trigger.hasClass('is-open'))` after each toggle, keeping the attribute in sync with the sidebar state

Fixes #37

## Test plan

- [x] Initial page load: `aria-expanded="false"` ✅
- [x] After clicking hamburger (open): `aria-expanded="true"` ✅
- [x] After clicking again (close): `aria-expanded="false"` ✅
- [x] No console errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)