### PR TITLE
docs: add .env.example and document MAPS_API_KEY in README

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+# Get a Maps JavaScript API key at https://console.cloud.google.com/
+MAPS_API_KEY=your_google_maps_api_key_here

--- a/README.md
+++ b/README.md
@@ -18,8 +18,11 @@ To install and build, execute the following:
 git clone https://github.com/bushidocodes/oldtown-map.git
 cd oldtown-map
 npm install
+cp .env.example .env   # then edit .env and add your MAPS_API_KEY
 npm run build
 ```
+
+The build injects `MAPS_API_KEY` from `.env` into `dist/index.html`. Without it the Google Maps embed will not load. Get a Maps JavaScript API key at https://console.cloud.google.com/.
 
 ...and then open ./dist/index.html in your browser of choice
 


### PR DESCRIPTION
## Summary

- Adds `.env.example` with the required `MAPS_API_KEY` variable and a link to Google Cloud Console
- Updates README setup instructions to include `cp .env.example .env` and an explanation of why the key is needed

Without this, a new contributor running `npm run build` gets a build that silently replaces `%%MAPS_API_KEY%%` with an empty string, producing a broken app with no error message.

Fixes #43

🤖 Generated with [Claude Code](https://claude.com/claude-code)