### PR TITLE
refactor: move hamburger toggle script from inline HTML into app.js

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -97,32 +97,6 @@
 
     <script async defer src="https://maps.googleapis.com/maps/api/js?key=%%MAPS_API_KEY%%&callback=initMap&loading=async" onerror="googleMapsError()"></script>
 
-    <!-- Menu Toggle Script -->
-    <script>
-    function hamburger_cross() {
-        var trigger = $('#menu-toggle');
-        if (trigger.hasClass('is-closed')) {
-            trigger.removeClass('is-closed').addClass('is-open');
-            $('.overlay').show();
-        } else {
-            trigger.removeClass('is-open').addClass('is-closed');
-            $('.overlay').hide();
-        }
-        trigger.attr('aria-expanded', trigger.hasClass('is-open'));
-    }
-
-    $("#menu-toggle").click(function(e) {
-        e.preventDefault();
-        hamburger_cross();
-        $("#wrapper").toggleClass("toggled");
-    });
-
-    $('.overlay').click(function() {
-        hamburger_cross();
-        $("#wrapper").removeClass("toggled");
-    });
-    </script>
-
 
 </body>
 

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -674,3 +674,26 @@ var ViewModel = function () {
 
 var vm = new ViewModel();
 ko.applyBindings(vm);
+
+function hamburger_cross() {
+    var trigger = $('#menu-toggle');
+    if (trigger.hasClass('is-closed')) {
+        trigger.removeClass('is-closed').addClass('is-open');
+        $('.overlay').show();
+    } else {
+        trigger.removeClass('is-open').addClass('is-closed');
+        $('.overlay').hide();
+    }
+    trigger.attr('aria-expanded', trigger.hasClass('is-open'));
+}
+
+$('#menu-toggle').click(function (e) {
+    e.preventDefault();
+    hamburger_cross();
+    $('#wrapper').toggleClass('toggled');
+});
+
+$('.overlay').click(function () {
+    hamburger_cross();
+    $('#wrapper').removeClass('toggled');
+});


### PR DESCRIPTION
## Summary

Moves the hamburger menu toggle logic (previously an inline `<script>` at `index.html:101-123`) into `src/js/app.js` so it runs through the Gulp build pipeline (Babel transpilation + minification + concatenation).

- `hamburger_cross()` defined as a top-level function in `app.js` — callable directly by `selectSite()` with no global dependency
- `#menu-toggle` click and `.overlay` click handlers registered at the bottom of `app.js`, after `ko.applyBindings`
- Inline `<script>` block removed from `index.html`

Fixes #44

## Test plan

- [x] Initial state: `aria-expanded="false"`, overlay hidden, wrapper not toggled
- [x] After hamburger click (open): `aria-expanded="true"`, overlay visible, wrapper toggled
- [x] After clicking a site (`selectSite`): `aria-expanded="false"`, overlay hidden, wrapper not toggled — full desync fix from #36 still intact
- [x] No console errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)