### PR TITLE
fix: sync markers with filteredSites on favorites toggle; fix selectMarker crash

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -47,7 +47,7 @@
             <ul class="sidebar-nav">
                 <li class="h3">Historic Sites</li>
                 <!--Append search element to the sidebar-->
-                <li><input type="text" class="form-control" data-bind="textInput: searchString, updateMarkers" placeholder="Search"
+                <li><input type="text" class="form-control" data-bind="textInput: searchString" placeholder="Search"
                     /></li>
                 <li><button class="btn btn-xs favorites-btn" data-bind="click: toggleShowFavorites, css: {'btn-warning': showFavoritesOnly, 'btn-default': !showFavoritesOnly()}">&#9733; Favorites</button></li>
                 <!--Append data model to the sidebar-->

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -140,6 +140,19 @@ function initMap() {
         });
         markers.push(marker);
     }
+
+    // Reactively sync marker visibility whenever filteredSites changes (covers both
+    // search input and favorites toggle). peek() avoids a dependency on the markers
+    // array itself since all markers are already pushed above.
+    ko.computed(function () {
+        var filtered = vm.filteredSites();
+        var allMarkers = markers.peek();
+        clearInfoWindow();
+        for (var i = 0; i < allMarkers.length; i++) {
+            var visible = filtered.some(function (site) { return site.name === allMarkers[i].title; });
+            allMarkers[i].setMap(visible ? map : null);
+        }
+    });
 }
 
 // clearInfoWindow() gracefully closes the infoWindow if it is open
@@ -304,27 +317,6 @@ function googleMapsError() {
     wasWarnedAboutMaps(true);
 }
 
-/*updateMarkers() is a custom Knockout binding handler that performs real time processing on the menu search field
-It clears the infoWindow if open and then iterates through the markers array.
-If a marker is in the filderedSites array, meaning that it meets the search criteria provided by the user,
-attach the marker to the map. Otherwise, detach the marker from the map.*/
-
-ko.bindingHandlers.updateMarkers = {
-    update: function (element, valueAccessor, allBindings, viewModel, bindingContext) {
-        clearInfoWindow();
-        for (var i = 0; i < markers().length; i++) {
-            let marker = markers()[i];
-            let markerInFilteredSites = false;
-            for (var j = 0; j < vm.filteredSites().length; j++) {
-                let site = vm.filteredSites()[j];
-                if (marker.title === site.name) {
-                    markerInFilteredSites = true;
-                }
-            }
-            markerInFilteredSites ? marker.setMap(map) : marker.setMap(null);
-        }
-    }
-};
 
 //Knockout Functionality
 var ViewModel = function () {
@@ -663,7 +655,7 @@ var ViewModel = function () {
     // selectMarker() is used to override the default behavior of when a marker is clicked. This ensures uniform
     // behavior between the sidebar and the map
     self.selectMarker = function (marker) {
-        var siteOfSelectedMarker = jQuery.grep(self.filteredSites(), function (site) {
+        var siteOfSelectedMarker = jQuery.grep(self.sites(), function (site) {
             return (site.name === marker.title);
         });
         clearInfoWindow();


### PR DESCRIPTION
## Summary

Two related fixes for the favorites mode bug:

**1. Marker visibility not synced on favorites toggle**

Replaced the `updateMarkers` custom Knockout binding (only wired to the search `<input>`) with a `ko.computed` inside `initMap()` that reads `vm.filteredSites()` as a tracked dependency. This ensures markers are shown/hidden whenever `filteredSites` changes — whether from the search field or the favorites toggle. Used `markers.peek()` to avoid a spurious dependency on the markers array itself.

**2. TypeError when clicking a non-favorite marker in favorites mode**

`selectMarker()` was searching `self.filteredSites()`, which only contains favorites in favorites mode. A non-favorite marker click produced `siteOfSelectedMarker[0] === undefined`. Changed to search `self.sites()` so all sites are always reachable from a marker click.

Fixes #46

## Test plan

- [x] Starred Gadsby's, enabled Favorites mode: 1 visible marker, 19 hidden — sync works
- [x] Called `selectMarker` on a non-favorite marker while in Favorites mode: no TypeError, InfoWindow opened correctly
- [x] Search still filters markers correctly (search "gadsby" → 1 visible)
- [x] No console errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)