### PR TITLE
chore: add Claude Code launch.json and gitignore settings.local.json

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -1,0 +1,11 @@
+{
+  "version": "0.0.1",
+  "configurations": [
+    {
+      "name": "oldtown-map",
+      "runtimeExecutable": "npx",
+      "runtimeArgs": ["serve", "dist", "-l", "3333"],
+      "port": 3333
+    }
+  ]
+}

--- a/.gitignore
+++ b/.gitignore
@@ -53,6 +53,10 @@ node_modules
 ##########################
 .env
 
+# Claude Code local settings #
+###############################
+.claude/settings.local.json
+
 # Built output #
 ################
 dist/


### PR DESCRIPTION
## Summary

- Adds `.claude/launch.json` — configures `npx serve dist -l 3333` as the dev server for Claude Code's built-in preview panel
- Adds `.claude/settings.local.json` to `.gitignore` — this file holds machine-specific hook configuration and should not be committed

🤖 Generated with [Claude Code](https://claude.com/claude-code)