### PR TITLE
Guard marker lookup against empty array

### DIFF
--- a/src/js/app.js
+++ b/src/js/app.js
@@ -642,14 +642,18 @@ var ViewModel = function () {
         var markerOfSelectedSite = jQuery.grep(markers(), function (marker) {
             return (marker.title === site.name);
         });
-        markerOfSelectedSite[0].setIcon(highlightedIcon);
+        if (markerOfSelectedSite.length > 0) {
+            markerOfSelectedSite[0].setIcon(highlightedIcon);
+        }
     };
 
     self.unhighlightMarkerOfSite = function (site) {
         var markerOfSelectedSite = jQuery.grep(markers(), function (marker) {
             return (marker.title === site.name);
         });
-        markerOfSelectedSite[0].setIcon(site.isFavorite() ? favoriteIcon : defaultIcon);
+        if (markerOfSelectedSite.length > 0) {
+            markerOfSelectedSite[0].setIcon(site.isFavorite() ? favoriteIcon : defaultIcon);
+        }
     };
 
     // selectMarker() is used to override the default behavior of when a marker is clicked. This ensures uniform


### PR DESCRIPTION
## Summary
Add a `length > 0` check before accessing `[0]` in both `highlightMarkerOfSite` and `unhighlightMarkerOfSite`. Without this guard, a filtered-out site (one not currently in the markers array) would throw a TypeError when the user hovers over a sidebar entry.

Closes #63