### PR TITLE
refactor: modernize app.js to ES2023 baseline

### DIFF
--- a/src/js/app.js
+++ b/src/js/app.js
@@ -19,8 +19,8 @@ class Site {
         this.lng = lng;
         this.description = description;
         this.wikipediaID = wikipediaID;
-        var favorites = JSON.parse(localStorage.getItem('oldtown-favorites') || '[]');
-        this.isFavorite = ko.observable(favorites.indexOf(name) >= 0);
+        const favorites = JSON.parse(localStorage.getItem('oldtown-favorites') ?? '[]');
+        this.isFavorite = ko.observable(favorites.includes(name));
     }
 }
 
@@ -31,22 +31,22 @@ class Site {
 // highlightenIcon is a dynamically generated (during initMap()) custom icon that is used for markers when they are
 // hovered over (via the marker itself or via the sidebar)
 
-var infoWindow = null;
-var map = null;
-var markers = ko.observableArray();
-var defaultIcon;
-var highlightedIcon;
-var favoriteIcon;
+let infoWindow = null;
+let map = null;
+const markers = ko.observableArray();
+let defaultIcon;
+let highlightedIcon;
+let favoriteIcon;
 
 // Global variable that stores a boolean to indicate if the end-use has been warned about Wikipedia or not.
 //This is to ensure an end-user is only warned once.
 
-var wasWarnedAboutWikipedia = ko.observable(false);
-var wasWarnedAboutMaps = ko.observable(false);
+const wasWarnedAboutWikipedia = ko.observable(false);
+const wasWarnedAboutMaps = ko.observable(false);
 
 // Custom Google Maps Style
 
-var styles =
+const styles =
     [
         {
             "featureType": "all", "elementType": "labels.text.fill",
@@ -111,7 +111,7 @@ function initMap() {
         center: { lat: 38.806, lng: -77.045 },
         zoom: 16,
         mapTypeId: google.maps.MapTypeId.ROADMAP,
-        styles: styles
+        styles
     });
 
     defaultIcon = makeMarkerIcon('ffffff');
@@ -122,18 +122,15 @@ function initMap() {
     marker twice and renders the infowindow for this marker, and add the marker to the markers array. All markers are
     diplayed on the map upon initial load*/
 
-    for (var i = 0; i < vm.sites().length; i++) {
-        let site = vm.sites()[i];
-        let marker = new google.maps.Marker({
+    for (const site of vm.sites()) {
+        const marker = new google.maps.Marker({
             position: { lat: site.lat, lng: site.lng },
-            map: map,
+            map,
             title: site.name,
             icon: site.isFavorite() ? favoriteIcon : defaultIcon
         });
         marker.site = site;
-        marker.addListener('click', function () {
-            vm.selectMarker(marker);
-        });
+        marker.addListener('click', () => vm.selectMarker(marker));
         //Event Listeners for mouseover and mouseout that modify the marker colors upon hover
         marker.addListener('mouseover', function () {
             this.setIcon(highlightedIcon);
@@ -147,13 +144,12 @@ function initMap() {
     // Reactively sync marker visibility whenever filteredSites changes (covers both
     // search input and favorites toggle). peek() avoids a dependency on the markers
     // array itself since all markers are already pushed above.
-    ko.computed(function () {
-        var filtered = vm.filteredSites();
-        var allMarkers = markers.peek();
+    ko.computed(() => {
+        const filtered = vm.filteredSites();
+        const allMarkers = markers.peek();
         clearInfoWindow();
-        for (var i = 0; i < allMarkers.length; i++) {
-            var visible = filtered.some(function (site) { return site.name === allMarkers[i].title; });
-            allMarkers[i].setMap(visible ? map : null);
+        for (const m of allMarkers) {
+            m.setMap(filtered.some(s => s.name === m.title) ? map : null);
         }
     });
 }
@@ -170,26 +166,26 @@ function clearInfoWindow() {
 DOM APIs (not HTML string concatenation), and opens the infoWindow after a delay. */
 
 function generateInfoWindow(site, map, marker, delay) {
-    var nameEl = document.createElement('strong');
+    const nameEl = document.createElement('strong');
     nameEl.textContent = site.name;
 
-    var container = document.createElement('div');
+    const container = document.createElement('div');
 
-    var descEl = document.createElement('p');
+    const descEl = document.createElement('p');
     descEl.innerHTML = site.description; // hardcoded data, not from external sources
     container.appendChild(descEl);
 
     if (site.wikipediaID) {
-        var imgHeader = document.createElement('strong');
+        const imgHeader = document.createElement('strong');
         imgHeader.appendChild(document.createTextNode('Images From '));
-        var wikiLink = document.createElement('a');
-        wikiLink.href = 'https://en.wikipedia.org/?curid=' + site.wikipediaID;
+        const wikiLink = document.createElement('a');
+        wikiLink.href = `https://en.wikipedia.org/?curid=${site.wikipediaID}`;
         wikiLink.textContent = 'Wikipedia Page';
         imgHeader.appendChild(wikiLink);
         container.appendChild(imgHeader);
         container.appendChild(document.createElement('br'));
 
-        var imagesContainer = document.createElement('div');
+        const imagesContainer = document.createElement('div');
         imagesContainer.style.maxHeight = '160px';
         imagesContainer.style.overflowY = 'auto';
         container.appendChild(imagesContainer);
@@ -197,7 +193,7 @@ function generateInfoWindow(site, map, marker, delay) {
     }
 
     infoWindow = new google.maps.InfoWindow({ headerContent: nameEl, content: container });
-    setTimeout(function () { infoWindow.open(map, marker); }, delay);
+    setTimeout(() => infoWindow.open(map, marker), delay);
 }
 
 // bounce() helper function bounced a marker a set number of times
@@ -208,7 +204,7 @@ function bounce(marker, numberOfBounces) {
     }
     // The BOUNCE animation lasts 700ms, so calculate duration and then use setTimeout()
     marker.setAnimation(google.maps.Animation.BOUNCE);
-    setTimeout(function () { marker.setAnimation(null); }, 700 * numberOfBounces);
+    setTimeout(() => marker.setAnimation(null), 700 * numberOfBounces);
 }
 
 /*makeMarkerIcon(markerColor) takes in a color in hexidecimal notation and creates a new marker icon of that color.
@@ -217,7 +213,7 @@ This function was presented in the Google Maps Udacity course, but I have update
 function makeMarkerIcon(markerColor) {
     return {
         path: google.maps.SymbolPath.CIRCLE,
-        fillColor: '#' + markerColor,
+        fillColor: `#${markerColor}`,
         fillOpacity: 1,
         strokeColor: '#333333',
         strokeWeight: 1.5,
@@ -225,94 +221,72 @@ function makeMarkerIcon(markerColor) {
     };
 }
 
-/*pullImagesFromWikipedia() issues JSON (not JSONP) requests to the Wikipedia MediaWiki API via CORS.
+/*pullImagesFromWikipedia() issues JSON requests to the Wikipedia MediaWiki API via CORS.
 It retrieves images from the site's Wikipedia page, filters out known junk images, and then calls
 resolveWikipediaImageURL for images that pass the filter.*/
 
-function pullImagesFromWikipedia(site, wikipediaID, imagesContainer) {
-    var wikipediaEndpoint = 'https://en.wikipedia.org/w/api.php';
-    var wikiRequestTimeout;
-    if (!wasWarnedAboutWikipedia()) {
-        wikiRequestTimeout = setTimeout(function () {
-            wasWarnedAboutWikipedia(true);
-        }, 3000);
-    }
-    $.ajax({
-        url: wikipediaEndpoint,
-        cache: true,
-        data: {
+const BLOCKED_IMAGE_TERMS = ['map', 'Map', 'logo', 'Logo', 'pog', 'Flag', 'book', 'question', 'Ambox', 'Nuvola', 'btn'];
+
+async function pullImagesFromWikipedia(site, wikipediaID, imagesContainer) {
+    const wikipediaEndpoint = 'https://en.wikipedia.org/w/api.php';
+    const timeout = !wasWarnedAboutWikipedia()
+        ? setTimeout(() => wasWarnedAboutWikipedia(true), 3000)
+        : null;
+
+    try {
+        const params = new URLSearchParams({
             action: 'query',
             pageids: wikipediaID,
             prop: 'images',
             format: 'json',
             origin: '*'
-        },
-        dataType: 'json',
-        success: (function (data) {
-            clearTimeout(wikiRequestTimeout);
-            const images = data.query.pages[wikipediaID].images || [];
-            for (var i = 0; i < images.length; i++) {
-                let imageName = images[i].title;
-                let process = true;
-                if (imageName.indexOf('map') >= 0) process = false;
-                if (imageName.indexOf('Map') >= 0) process = false;
-                if (imageName.indexOf('logo') >= 0) process = false;
-                if (imageName.indexOf('Logo') >= 0) process = false;
-                if (imageName.indexOf('pog') >= 0) process = false;
-                if (imageName.indexOf('Flag') >= 0) process = false;
-                if (imageName.indexOf('book') >= 0) process = false;
-                if (imageName.indexOf('question') >= 0) process = false;
-                if (imageName.indexOf('Ambox') >= 0) process = false;
-                if (imageName.indexOf('Nuvola') >= 0) process = false;
-                if (imageName.indexOf('btn') >= 0) process = false;
-                if (process) resolveWikipediaImageURL(imageName, imagesContainer);
+        });
+        const response = await fetch(`${wikipediaEndpoint}?${params}`);
+        const data = await response.json();
+        clearTimeout(timeout);
+        const images = data.query.pages[wikipediaID].images ?? [];
+        for (const image of images) {
+            if (!BLOCKED_IMAGE_TERMS.some(term => image.title.includes(term))) {
+                resolveWikipediaImageURL(image.title, imagesContainer);
             }
-        }),
-        error: function () {
-            clearTimeout(wikiRequestTimeout);
         }
-    });
+    } catch {
+        clearTimeout(timeout);
+    }
 
-    /* resolveWikipediaImageURL retrieves the image URL via JSON/CORS, validates it is an HTTPS
+    /* resolveWikipediaImageURL retrieves the image URL via fetch/CORS, validates it is an HTTPS
     Wikimedia URL, then builds the <a>/<img> elements via DOM APIs and appends to imagesContainer. */
-    function resolveWikipediaImageURL(imageName, imagesContainer) {
-        $.ajax({
-            url: wikipediaEndpoint,
-            cache: true,
-            data: {
+    async function resolveWikipediaImageURL(imageName, imagesContainer) {
+        try {
+            const params = new URLSearchParams({
                 action: 'query',
                 prop: 'imageinfo',
                 iiprop: 'url',
                 titles: imageName,
                 format: 'json',
                 origin: '*'
-            },
-            dataType: 'json',
-            success: (function (data) {
-                var pageId = Object.keys(data.query.pages)[0];
-                var imageUrl = data.query.pages[pageId].imageinfo[0].url;
-                try {
-                    var parsed = new URL(imageUrl);
-                    if (parsed.protocol !== 'https:') return;
-                    if (!parsed.hostname.endsWith('.wikimedia.org') && !parsed.hostname.endsWith('.wikipedia.org')) return;
-                } catch (e) {
-                    return;
-                }
-                var anchor = document.createElement('a');
-                anchor.href = imageUrl;
-                var img = document.createElement('img');
-                img.className = 'wiki-img img-circle';
-                img.src = imageUrl;
-                img.alt = imageName.replace(/^File:/i, '').replace(/\.[^.]+$/, '').replace(/_/g, ' ');
-                img.style.height = '80px';
-                img.style.width = '80px';
-                anchor.appendChild(img);
-                imagesContainer.appendChild(anchor);
-            }),
-            error: function () {}
-        });
+            });
+            const response = await fetch(`${wikipediaEndpoint}?${params}`);
+            const data = await response.json();
+            const [pageId] = Object.keys(data.query.pages);
+            const imageUrl = data.query.pages[pageId].imageinfo[0].url;
+            const parsed = new URL(imageUrl);
+            if (parsed.protocol !== 'https:') return;
+            if (!parsed.hostname.endsWith('.wikimedia.org') && !parsed.hostname.endsWith('.wikipedia.org')) return;
+            const anchor = document.createElement('a');
+            anchor.href = imageUrl;
+            const img = document.createElement('img');
+            img.className = 'wiki-img img-circle';
+            img.src = imageUrl;
+            img.alt = imageName.replace(/^File:/i, '').replace(/\.[^.]+$/, '').replace(/_/g, ' ');
+            img.style.height = '80px';
+            img.style.width = '80px';
+            anchor.appendChild(img);
+            imagesContainer.appendChild(anchor);
+        } catch {
+            // network or parse error — discard this image silently
+        }
     }
-
 }
 
 // googleError performs error handling for the Google Maps API.
@@ -322,10 +296,10 @@ function googleMapsError() {
 
 
 //Knockout Functionality
-var ViewModel = function () {
+const ViewModel = function () {
 
     // ViewModel Data
-    var self = this;
+    const self = this;
 
     // Intially set searchString, which is bound to sidebar search field, to an empty string
     self.searchString = ko.observable('');
@@ -342,7 +316,7 @@ var ViewModel = function () {
             "221 King St, Alexandria, VA 22314",
             38.804628,
             -77.042357,
-            "Alexandria’s Visitor's Center was originally the home of William Ramsay, one of the three original " +
+            "Alexandria's Visitor's Center was originally the home of William Ramsay, one of the three original " +
             "Scottish settlers that settled the area in November 1748 and petitioned the House of Burgesses to " +
             "establish a town.",
             null
@@ -367,11 +341,11 @@ var ViewModel = function () {
             "134 N Royal St, Alexandria, VA 22314",
             38.805554,
             -77.043619,
-            "Discover Alexandria’s five-star hotel of the 18th century! The Museum consists of the c. 1785 tavern " +
+            "Discover Alexandria's five-star hotel of the 18th century! The Museum consists of the c. 1785 tavern " +
             "and the 1792 City Tavern and Hotel. Both were constructed by John Wise but made famous by " +
             "tavernkeeper John Gadsby. His establishment was the center of political, business, and social " +
-            "life in Alexandria and in the new federal city of Washington, D.C. The City Tavern’s Ballroom was " +
-            "the location of George Washington’s Birthnight Ball in 1798 and 1799, as well as Thomas Jefferson’s " +
+            "life in Alexandria and in the new federal city of Washington, D.C. The City Tavern's Ballroom was " +
+            "the location of George Washington's Birthnight Ball in 1798 and 1799, as well as Thomas Jefferson's " +
             "Inaugural Banquet in 1801. The museum offers tours, programs and special events. " +
             "Apr.-Oct.: Sun. & Mon. 1-5 p.m., Tues.-Sat. 10 a.m.-5 p.m.; " +
             "Nov.-March.: Wed.-Sat. 11 a.m.-4 p.m., Sun. 1-4 p.m",
@@ -404,7 +378,7 @@ var ViewModel = function () {
             -77.045208,
             "Robert E. Lee left this home that he loved so well to enter West Point. After Appomattox he returned " +
             "and climbed the wall to see if the snowballs were in bloom. George Washington dined here when it was " +
-            "the home of William Fitzhugh, Lee’s kinsman and his wife’s grandfather. Lafayette visited here in 1824.",
+            "the home of William Fitzhugh, Lee's kinsman and his wife's grandfather. Lafayette visited here in 1824.",
             30089861
         ),
         new Site(
@@ -423,7 +397,7 @@ var ViewModel = function () {
             "220 N Washington St, Alexandria, VA 22314",
             38.807214,
             -77.046751,
-            "Constructed around 1796-1797, Lloyd House is one of the best examples of Alexandria’s late " +
+            "Constructed around 1796-1797, Lloyd House is one of the best examples of Alexandria's late " +
             "eighteenth-century Georgian style, and one of five buildings of the Georgian style remaining in the " +
             "city. Lloyd House is particularly important to the streetscape of Washington Street, part of the George " +
             "Washington Memorial Parkway.",
@@ -544,7 +518,7 @@ var ViewModel = function () {
             "115 Prince St, Alexandria, VA 22314",
             38.803433,
             -77.041098,
-            "Captain’s Row is a line of homes once heavily inhabited by sea captains in the days when Alexandria " +
+            "Captain's Row is a line of homes once heavily inhabited by sea captains in the days when Alexandria " +
             "was a major commercial port and clipper ships and brigs lined the Potomac waterfront. The homes were " +
             "mostly rebuilt in 1827 after a fire. The street retains the historic Revolutionary War cobblestone " +
             "streets that once lined much of Old Town. Local folklore says the cobblestones were brought from " +
@@ -585,17 +559,15 @@ var ViewModel = function () {
     // filteredSites is a Knockout Computed object that stores all sites with a title that matches searchString
     // without regard to case. This filter implementation is based on Ryan Niemeyer's Array Filtering section
     // found at http://www.knockmeout.net/2011/04/utility-functions-in-knockoutjs.html
-    self.filteredSites = ko.computed(function () {
-        var sites = self.showFavoritesOnly()
-            ? ko.utils.arrayFilter(self.sites(), function (site) { return site.isFavorite(); })
+    self.filteredSites = ko.computed(() => {
+        const sites = self.showFavoritesOnly()
+            ? self.sites().filter(site => site.isFavorite())
             : self.sites();
         if (self.searchString() === '') {
             return sites;
         }
-        var filter = self.searchString().toLowerCase();
-        return ko.utils.arrayFilter(sites, function (site) {
-            return site.name.toLowerCase().indexOf(filter) >= 0;
-        });
+        const filter = self.searchString().toLowerCase();
+        return sites.filter(site => site.name.toLowerCase().includes(filter));
     });
 
 
@@ -605,9 +577,7 @@ var ViewModel = function () {
     // It finds the marker with a title that matches the name of the selected site, bounces that marker twice, and
     // then renders the infoWindow on that marker using the data from the selected site.
     self.selectSite = function (site) {
-        var markerOfSelectedSite = jQuery.grep(markers(), function (marker) {
-            return (marker.title === site.name);
-        });
+        const marker = markers().find(m => m.title === site.name);
         clearInfoWindow();
         //Don't close the sidebar automatically if the window is so wide that the infowindow is fully visible on the visible portion of the map div
         if ($(window).width() < 1500) {
@@ -615,8 +585,8 @@ var ViewModel = function () {
             $("#wrapper").toggleClass("toggled");
         }
         map.panTo({ lat: site.lat, lng: site.lng });
-        bounce(markerOfSelectedSite[0], 2);
-        generateInfoWindow(site, map, markerOfSelectedSite[0], 1400);
+        bounce(marker, 2);
+        generateInfoWindow(site, map, marker, 1400);
     };
 
     self.toggleShowFavorites = function () {
@@ -624,58 +594,45 @@ var ViewModel = function () {
     };
 
     self.toggleFavorite = function (site) {
-        var newValue = !site.isFavorite();
+        const newValue = !site.isFavorite();
         site.isFavorite(newValue);
-        var favorites = JSON.parse(localStorage.getItem('oldtown-favorites') || '[]');
+        let favorites = JSON.parse(localStorage.getItem('oldtown-favorites') ?? '[]');
         if (newValue) {
-            if (favorites.indexOf(site.name) < 0) favorites.push(site.name);
+            if (!favorites.includes(site.name)) favorites.push(site.name);
         } else {
-            favorites = favorites.filter(function (n) { return n !== site.name; });
+            favorites = favorites.filter(n => n !== site.name);
         }
         localStorage.setItem('oldtown-favorites', JSON.stringify(favorites));
-        var markerArr = jQuery.grep(markers(), function (marker) { return marker.title === site.name; });
-        if (markerArr.length) {
-            markerArr[0].setIcon(newValue ? favoriteIcon : defaultIcon);
-        }
+        const marker = markers().find(m => m.title === site.name);
+        marker?.setIcon(newValue ? favoriteIcon : defaultIcon);
     };
 
     // highlightMarkerOfSite() and unhighlightMarkerOfSite() are used to allow the end user to hover over sites in
     // the side bar and see the associated marker of that site highlighted on the map.
     self.highlightMarkerOfSite = function (site) {
-        var markerOfSelectedSite = jQuery.grep(markers(), function (marker) {
-            return (marker.title === site.name);
-        });
-        if (markerOfSelectedSite.length > 0) {
-            markerOfSelectedSite[0].setIcon(highlightedIcon);
-        }
+        markers().find(m => m.title === site.name)?.setIcon(highlightedIcon);
     };
 
     self.unhighlightMarkerOfSite = function (site) {
-        var markerOfSelectedSite = jQuery.grep(markers(), function (marker) {
-            return (marker.title === site.name);
-        });
-        if (markerOfSelectedSite.length > 0) {
-            markerOfSelectedSite[0].setIcon(site.isFavorite() ? favoriteIcon : defaultIcon);
-        }
+        const marker = markers().find(m => m.title === site.name);
+        marker?.setIcon(site.isFavorite() ? favoriteIcon : defaultIcon);
     };
 
     // selectMarker() is used to override the default behavior of when a marker is clicked. This ensures uniform
     // behavior between the sidebar and the map
     self.selectMarker = function (marker) {
-        var siteOfSelectedMarker = jQuery.grep(self.sites(), function (site) {
-            return (site.name === marker.title);
-        });
+        const site = self.sites().find(s => s.name === marker.title);
         clearInfoWindow();
         bounce(marker, 2);
-        generateInfoWindow(siteOfSelectedMarker[0], map, marker, 1400);
+        generateInfoWindow(site, map, marker, 1400);
     };
 }; //endViewModel
 
-var vm = new ViewModel();
+const vm = new ViewModel();
 ko.applyBindings(vm);
 
 function hamburger_cross() {
-    var trigger = $('#menu-toggle');
+    const trigger = $('#menu-toggle');
     if (trigger.hasClass('is-closed')) {
         trigger.removeClass('is-closed').addClass('is-open');
         $('.overlay').show();
@@ -686,13 +643,13 @@ function hamburger_cross() {
     trigger.attr('aria-expanded', trigger.hasClass('is-open'));
 }
 
-$('#menu-toggle').click(function (e) {
+$('#menu-toggle').click((e) => {
     e.preventDefault();
     hamburger_cross();
     $('#wrapper').toggleClass('toggled');
 });
 
-$('.overlay').click(function () {
+$('.overlay').click(() => {
     hamburger_cross();
     $('#wrapper').removeClass('toggled');
 });


### PR DESCRIPTION
## Summary

- Replace all `var` with `const`/`let` (`const` for bindings that are never reassigned)
- Arrow functions for all callbacks that don't rely on a dynamic `this`; `mouseover`/`mouseout` Google Maps listeners kept as `function()` since the Maps API sets `this` to the marker
- Template literals replace string concatenation
- `includes()` replaces every `indexOf() >= 0` guard
- `for...of` replaces index-based loops
- Optional chaining (`?.`) replaces length-guard + `[0]` single-match patterns
- Nullish coalescing (`??`) replaces `||` for `localStorage`/`null` defaults
- `Array.prototype.filter()` replaces `jQuery.grep()` and `ko.utils.arrayFilter()`
- `Array.prototype.find()` replaces `jQuery.grep()[0]` single-match lookups
- `fetch` + `async`/`await` replaces `$.ajax` in `pullImagesFromWikipedia`
- `URLSearchParams` builds query strings instead of `$.ajax` `data` objects
- `BLOCKED_IMAGE_TERMS` constant + `Array.some()` collapses 11 sequential `if`-statements in the image title filter
- Shorthand property syntax (`map`, `styles`) in object literals
- Array destructuring for `Object.keys()` single-element extraction

## Test plan

- [ ] Map loads and all 20 site markers appear
- [ ] Clicking a marker opens an InfoWindow with the correct site name and description
- [ ] Wikipedia images load for sites that have a `wikipediaID`
- [ ] Sidebar search filters both the list and map markers
- [ ] Favorites toggle persists across page reload
- [ ] Hovering a sidebar item highlights the corresponding marker
- [ ] Hamburger menu opens/closes on narrow viewports

🤖 Generated with [Claude Code](https://claude.com/claude-code)