### PR TITLE
chore: add Dependabot for automated dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+---
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+---


### PR DESCRIPTION
## Summary
Adds Dependabot configuration to automate dependency updates for: github-actions, npm.
Updates will open PRs weekly.

## Ecosystems tracked
- `github-actions`
- `npm`
