### PR TITLE
refactor: migrate build tooling from CommonJS to ESM

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,5 +1,3 @@
-'use strict';
-
 // Gulp 5 build pipeline for oldtown-map.
 //
 // Migrated from gulp 3.9.1, which aborted on Node >= 12 with
@@ -16,13 +14,13 @@
 //     vendor libraries (jQuery, Bootstrap, Knockout, Knockstrap) are vendored
 //     under dist/bower_components and referenced directly by dist/index.html.
 
-const { src, dest, parallel } = require('gulp');
-const concat = require('gulp-concat');
-const htmlmin = require('gulp-html-minifier-terser');
-const cleanCSS = require('gulp-clean-css');
-const babel = require('gulp-babel');
-const replace = require('gulp-replace');
-require('dotenv').config();
+import { src, dest, parallel } from 'gulp';
+import concat from 'gulp-concat';
+import htmlmin from 'gulp-html-minifier-terser';
+import cleanCSS from 'gulp-clean-css';
+import babel from 'gulp-babel';
+import replace from 'gulp-replace';
+import 'dotenv/config';
 
 // Define the directory structure of the project
 const htmlSrc = './src/*.html';
@@ -63,9 +61,5 @@ function images() {
 
 const build = parallel(html, css, js, images);
 
-exports.html = html;
-exports.css = css;
-exports.js = js;
-exports.images = images;
-exports.build = build;
-exports.default = build;
+export { html, css, js, images, build };
+export default build;

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "oldtown-map",
   "version": "1.0.0",
   "description": "oldtown-map is a JavaScript application that renders historic locations in Old Town Alexandria Virginia on a Google Map as markers. It provides a sidebar with a list of these locations and a searchable filter list that filters both the list and the markers on the map. Selecting a marker or a location on the list opens an InfoView with static information about the location. If an item has a Wikipedia ID, then the application displays a link to the Wikipedia page for the location and the infoView loads and scales thumbnail versions of the images on the locaiton's wikipedia page.",
-  "main": "index.js",
+  "type": "module",
   "engines": {
     "node": ">=18"
   },


### PR DESCRIPTION
## Summary

Closes #71

- Added `"type": "module"` to `package.json` and removed the unused `"main"` field
- Converted `gulpfile.js` to ESM: `require()` → `import`, `require('dotenv').config()` → `import 'dotenv/config'`, `exports.*` → `export { html, css, js, images, build }` + `export default build`, removed redundant `'use strict'`

`src/js/app.js` is unchanged — it's a browser-targeted script with no module system that gets processed as raw text by Babel; `"type": "module"` doesn't affect how gulp-babel handles it.

## Test plan

- [x] `npm run build` completes successfully — all four tasks (html, css, js, images) run and finish cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)