### PR TITLE
Tighten component types

### DIFF
--- a/src/js/base.ts
+++ b/src/js/base.ts
@@ -1,45 +1,27 @@
 import { render, type TemplateResult } from 'lit-html';
+import type { EmitArgs, OldtownEventMap } from './events.js';
+
+/** Generic constructor type, used by the {@link reactiveProps} mixin. */
+type Constructor<T = object> = new (...args: any[]) => T;
 
 /**
  * Minimal base class for custom elements that render with lit-html into a shadow root.
  *
- * Subclasses:
- *   - declare reactive properties via `static observedProps = ['foo', 'bar']`
- *     (assigning to `this.foo` schedules a re-render), mirror each with a
- *     `declare foo: T;` field so TypeScript knows about the accessor the
- *     constructor defines dynamically, and
- *   - implement `template()` returning a lit-html `TemplateResult`.
+ * Reactive properties are added with the {@link reactiveProps} mixin; subclasses
+ * implement `template()` returning a lit-html `TemplateResult`.
  *
- * Renders are batched on the microtask queue so setting several properties in a
- * single turn only triggers one render — the role Knockout's dependency tracking
- * used to play.
+ * Renders are batched on the microtask queue so setting several properties in a single
+ * turn only triggers one render — the role Knockout's dependency tracking used to play.
  */
 export class Component extends HTMLElement {
-    static observedProps?: string[];
-
     // `attachShadow({ mode: 'open' })` in the constructor guarantees this is set.
     declare readonly shadowRoot: ShadowRoot;
 
-    private _props: Record<string, unknown> = {};
     private _renderScheduled = false;
 
     constructor() {
         super();
         this.attachShadow({ mode: 'open' });
-
-        for (const name of (this.constructor as typeof Component).observedProps ?? []) {
-            Object.defineProperty(this, name, {
-                configurable: true,
-                enumerable: true,
-                get(this: Component) {
-                    return this._props[name];
-                },
-                set(this: Component, value: unknown) {
-                    this._props[name] = value;
-                    this.requestRender();
-                },
-            });
-        }
     }
 
     connectedCallback(): void {
@@ -55,13 +37,62 @@ export class Component extends HTMLElement {
         });
     }
 
-    /** Dispatch a composed CustomEvent that crosses shadow boundaries to ancestors. */
-    emit<T = unknown>(type: string, detail?: T): void {
-        this.dispatchEvent(new CustomEvent(type, { detail, bubbles: true, composed: true }));
+    /**
+     * Dispatch a composed CustomEvent that crosses shadow boundaries to ancestors.
+     * Typed against {@link OldtownEventMap}: the event name fixes the detail type,
+     * and `void` events take no second argument.
+     */
+    emit<K extends keyof OldtownEventMap>(type: K, ...args: EmitArgs<K>): void;
+    emit(type: string, ...args: unknown[]): void {
+        this.dispatchEvent(new CustomEvent(type, { detail: args[0], bubbles: true, composed: true }));
     }
 
     /** Subclasses override this to return a lit-html template. */
     template(): TemplateResult | null {
         return null;
     }
+}
+
+/**
+ * Mixin that adds reactive properties to a {@link Component} subclass: assigning to any
+ * of them stores the value and schedules a re-render. The `defaults` object is the single
+ * source of truth — its keys and value types become the element's typed properties, so a
+ * renamed or mistyped property is a compile error. (The previous `static observedProps`
+ * string list could silently drift from the declared fields; this can't.)
+ *
+ *     class AppNavbar extends reactiveProps(Component, { open: false }) {
+ *         template() { return html`…${this.open}…`; } // this.open is typed `boolean`
+ *     }
+ */
+export function reactiveProps<TBase extends Constructor<Component>, P extends Record<string, unknown>>(
+    Base: TBase,
+    defaults: P,
+): TBase & Constructor<P> {
+    // Per-instance value store, keyed off the element so the prototype accessors below
+    // stay shared. Defined in the closure so no backing field leaks onto the element.
+    const store = new WeakMap<Component, Record<string, unknown>>();
+
+    class WithReactiveProps extends Base {
+        constructor(...args: any[]) {
+            super(...args);
+            store.set(this, { ...defaults });
+        }
+    }
+
+    for (const key of Object.keys(defaults)) {
+        Object.defineProperty(WithReactiveProps.prototype, key, {
+            configurable: true,
+            enumerable: true,
+            get(this: Component): unknown {
+                return store.get(this)?.[key];
+            },
+            set(this: Component, value: unknown) {
+                const props = store.get(this);
+                if (props) props[key] = value;
+                this.requestRender();
+            },
+        });
+    }
+
+    return WithReactiveProps as unknown as TBase & Constructor<P>;
 }

--- a/src/js/components/app-alert.ts
+++ b/src/js/components/app-alert.ts
@@ -1,14 +1,11 @@
 import { html, type TemplateResult } from 'lit-html';
-import { Component } from '../base.js';
+import { Component, reactiveProps } from '../base.js';
 
 /**
  * Dismissible warning banner that floats over the top-left of the map.
  * Props: message (string). Emits `dismiss` when the close button is clicked.
  */
-export class AppAlert extends Component {
-    static observedProps = ['message'];
-    declare message: string;
-
+export class AppAlert extends reactiveProps(Component, { message: '' }) {
     template(): TemplateResult {
         return html`
             <style>

--- a/src/js/components/app-navbar.ts
+++ b/src/js/components/app-navbar.ts
@@ -1,14 +1,11 @@
 import { html, type TemplateResult } from 'lit-html';
-import { Component } from '../base.js';
+import { Component, reactiveProps } from '../base.js';
 
 /**
  * Top navigation bar with the app title and a hamburger button that toggles the
  * sidebar drawer. Emits `toggle-sidebar` on click.
  */
-export class AppNavbar extends Component {
-    static observedProps = ['open'];
-    declare open: boolean;
-
+export class AppNavbar extends reactiveProps(Component, { open: false }) {
     template(): TemplateResult {
         return html`
             <style>

--- a/src/js/components/map-view.ts
+++ b/src/js/components/map-view.ts
@@ -12,7 +12,12 @@ const TILE_ATTRIBUTION =
 const CENTER: L.LatLngTuple = [38.806, -77.045];
 const ZOOM = 16;
 
-const MARKER_BASE = { radius: 9, color: '#333333', weight: 1.5, fillOpacity: 1 };
+const MARKER_BASE = {
+    radius: 9,
+    color: '#333333',
+    weight: 1.5,
+    fillOpacity: 1,
+} satisfies L.CircleMarkerOptions;
 const COLOR_DEFAULT = '#ffffff';
 const COLOR_HIGHLIGHT = '#ff661a';
 const COLOR_FAVORITE = '#ffd700';
@@ -23,6 +28,16 @@ const BLOCKED_IMAGE_TERMS = [
 ];
 
 const WIKIPEDIA_ENDPOINT = 'https://en.wikipedia.org/w/api.php';
+
+// Shapes of the two MediaWiki API responses this component consumes. Only the
+// fields actually read are modeled; everything is optional because the payload
+// is untrusted (a missing page, a renamed key, etc. must not throw).
+interface WikiImagesResponse {
+    query?: { pages?: Record<string, { images?: Array<{ title: string }> }> };
+}
+interface WikiImageInfoResponse {
+    query?: { pages?: Record<string, { imageinfo?: Array<{ url: string }> }> };
+}
 
 /**
  * Leaflet map wrapper. Unlike the lit-html components, this element drives its
@@ -113,8 +128,8 @@ export class MapView extends HTMLElement {
         this.#buildMarkers();
     }
 
-    #emit(type: string, detail?: unknown): void {
-        this.dispatchEvent(new CustomEvent(type, { detail, bubbles: true, composed: true }));
+    #emit(type: 'tile-error' | 'wikipedia-error'): void {
+        this.dispatchEvent(new CustomEvent(type, { bubbles: true, composed: true }));
     }
 
     set sites(value: Site[] | undefined) {
@@ -295,9 +310,9 @@ export class MapView extends HTMLElement {
                 origin: '*',
             });
             const response = await fetch(`${WIKIPEDIA_ENDPOINT}?${params}`);
-            const data = await response.json();
+            const data = (await response.json()) as WikiImagesResponse;
             clearTimeout(timeout);
-            const images = data.query.pages[wikipediaID].images ?? [];
+            const images = data.query?.pages?.[wikipediaID]?.images ?? [];
             for (const image of images) {
                 if (!BLOCKED_IMAGE_TERMS.some((term) => image.title.includes(term))) {
                     this.#resolveImageURL(image.title, imagesContainer);
@@ -319,9 +334,11 @@ export class MapView extends HTMLElement {
                 origin: '*',
             });
             const response = await fetch(`${WIKIPEDIA_ENDPOINT}?${params}`);
-            const data = await response.json();
-            const [pageId] = Object.keys(data.query.pages);
-            const imageUrl = data.query.pages[pageId].imageinfo[0].url;
+            const data = (await response.json()) as WikiImageInfoResponse;
+            const pages = data.query?.pages;
+            const pageId = pages ? Object.keys(pages)[0] : undefined;
+            const imageUrl = pageId ? pages?.[pageId]?.imageinfo?.[0]?.url : undefined;
+            if (!imageUrl) return;
             const parsed = new URL(imageUrl);
             if (parsed.protocol !== 'https:') return;
             if (!parsed.hostname.endsWith('.wikimedia.org') && !parsed.hostname.endsWith('.wikipedia.org')) {

--- a/src/js/components/oldtown-app.ts
+++ b/src/js/components/oldtown-app.ts
@@ -6,6 +6,7 @@ import './site-sidebar.js';
 import './app-alert.js';
 import './map-view.js';
 import type { MapView } from './map-view.js';
+import type { OldtownEvent } from '../events.js';
 
 const FAVORITES_KEY = 'oldtown-favorites';
 // Below this viewport width, selecting a site auto-closes the drawer so the
@@ -27,7 +28,8 @@ export class OldtownApp extends Component {
 
     #loadFavorites(): string[] {
         try {
-            return JSON.parse(localStorage.getItem(FAVORITES_KEY) ?? '[]');
+            const parsed: unknown = JSON.parse(localStorage.getItem(FAVORITES_KEY) ?? '[]');
+            return Array.isArray(parsed) ? parsed.filter((x): x is string => typeof x === 'string') : [];
         } catch {
             return [];
         }
@@ -54,7 +56,7 @@ export class OldtownApp extends Component {
 
     // --- event handlers -----------------------------------------------------
 
-    #onSearchChange = (e: CustomEvent<string>): void => {
+    #onSearchChange = (e: OldtownEvent<'search-change'>): void => {
         this.#searchString = e.detail;
         this.requestRender();
     };
@@ -74,7 +76,7 @@ export class OldtownApp extends Component {
         this.requestRender();
     };
 
-    #onSiteSelect = (e: CustomEvent<Site>): void => {
+    #onSiteSelect = (e: OldtownEvent<'site-select'>): void => {
         const site = e.detail;
         if (window.innerWidth < AUTOCLOSE_WIDTH) {
             this.#sidebarOpen = false;
@@ -83,7 +85,7 @@ export class OldtownApp extends Component {
         this.#mapView?.focusSite(site);
     };
 
-    #onFavoriteToggle = (e: CustomEvent<Site>): void => {
+    #onFavoriteToggle = (e: OldtownEvent<'favorite-toggle'>): void => {
         const { name } = e.detail;
         if (this.#favorites.has(name)) this.#favorites.delete(name);
         else this.#favorites.add(name);
@@ -92,8 +94,8 @@ export class OldtownApp extends Component {
         this.requestRender();
     };
 
-    #onSiteHover = (e: CustomEvent<Site>): void => this.#mapView?.highlight(e.detail.name);
-    #onSiteUnhover = (e: CustomEvent<Site>): void => this.#mapView?.unhighlight(e.detail.name);
+    #onSiteHover = (e: OldtownEvent<'site-hover'>): void => this.#mapView?.highlight(e.detail.name);
+    #onSiteUnhover = (e: OldtownEvent<'site-unhover'>): void => this.#mapView?.unhighlight(e.detail.name);
 
     #onWikipediaError = (): void => {
         this.#wikipediaWarning = true;

--- a/src/js/components/site-list-item.ts
+++ b/src/js/components/site-list-item.ts
@@ -1,5 +1,5 @@
 import { html, type TemplateResult } from 'lit-html';
-import { Component } from '../base.js';
+import { Component, reactiveProps } from '../base.js';
 import type { Site } from '../sites.js';
 
 /**
@@ -10,11 +10,10 @@ import type { Site } from '../sites.js';
  *   - `favorite-toggle` when the star is clicked (does not also select)
  *   - `site-hover` / `site-unhover` on pointer enter/leave
  */
-export class SiteListItem extends Component {
-    static observedProps = ['site', 'favorite'];
-    declare site: Site | undefined;
-    declare favorite: boolean;
-
+export class SiteListItem extends reactiveProps(Component, {
+    site: undefined as Site | undefined,
+    favorite: false,
+}) {
     template(): TemplateResult {
         const site = this.site;
         if (!site) return html``;
@@ -71,7 +70,7 @@ export class SiteListItem extends Component {
 
     #onStarClick = (event: Event): void => {
         event.stopPropagation();
-        this.emit('favorite-toggle', this.site);
+        if (this.site) this.emit('favorite-toggle', this.site);
     };
 }
 

--- a/src/js/components/site-sidebar.ts
+++ b/src/js/components/site-sidebar.ts
@@ -1,5 +1,5 @@
 import { html, type TemplateResult } from 'lit-html';
-import { Component } from '../base.js';
+import { Component, reactiveProps } from '../base.js';
 import './site-list-item.js';
 import type { Site } from '../sites.js';
 
@@ -17,16 +17,15 @@ import type { Site } from '../sites.js';
  *
  * Emits: `search-change` (detail: string), `toggle-favorites`.
  */
-export class SiteSidebar extends Component {
-    static observedProps = ['sites', 'favorites', 'searchString', 'showFavoritesOnly'];
-    declare sites: Site[] | undefined;
-    declare favorites: Set<string> | undefined;
-    declare searchString: string | undefined;
-    declare showFavoritesOnly: boolean | undefined;
-
+export class SiteSidebar extends reactiveProps(Component, {
+    sites: [] as Site[],
+    favorites: new Set<string>(),
+    searchString: '',
+    showFavoritesOnly: false,
+}) {
     template(): TemplateResult {
-        const sites = this.sites ?? [];
-        const favorites = this.favorites ?? new Set<string>();
+        const sites = this.sites;
+        const favorites = this.favorites;
         return html`
             <style>
                 :host {

--- a/src/js/events.ts
+++ b/src/js/events.ts
@@ -1,0 +1,29 @@
+import type { Site } from './sites.js';
+
+/**
+ * The custom events that flow up from the components to <oldtown-app>, mapped to
+ * their `CustomEvent` detail type. `void` means the event carries no detail.
+ *
+ * This is the single source of truth for the app's event contract: `Component.emit`
+ * is typed against it (so emitting the wrong detail for an event name is a compile
+ * error), and listeners can type their handlers with `OldtownEvent<'name'>`.
+ */
+export interface OldtownEventMap {
+    'toggle-sidebar': void;
+    'search-change': string;
+    'toggle-favorites': void;
+    'site-select': Site;
+    'favorite-toggle': Site;
+    'site-hover': Site;
+    'site-unhover': Site;
+    'wikipedia-error': void;
+    'tile-error': void;
+    dismiss: void;
+}
+
+/** Trailing arguments to `emit(name, …)`: events whose detail is `void` take none. */
+export type EmitArgs<K extends keyof OldtownEventMap> =
+    OldtownEventMap[K] extends void ? [] : [detail: OldtownEventMap[K]];
+
+/** The `CustomEvent` delivered for a given event name. */
+export type OldtownEvent<K extends keyof OldtownEventMap> = CustomEvent<OldtownEventMap[K]>;


### PR DESCRIPTION
Follow-up to the TypeScript migration (#79): strengthen the types across the component layer. **No behavior change** — verified with `tsc`, `vite build`, and a browser smoke test of every interaction (search, favorites, favorites-only, drawer toggle, Wikipedia popup).

## Changes

**Typed custom-event map** — new [`src/js/events.ts`](src/js/events.ts) maps each event name to its `CustomEvent` detail type. `Component.emit` is now an overload against it, so the name fixes the detail and `void` events take no second arg; listeners type handlers as `OldtownEvent<'name'>`. Emitting the wrong detail, an extra arg, or an unknown event is a compile error (verified with a throwaway probe).

**`reactiveProps` mixin replaces `static observedProps`** — the old reactive-prop system used a stringly-typed array (`['open']`) plus a parallel `declare open: boolean`, which could silently drift. Now:
```ts
export class AppNavbar extends reactiveProps(Component, { open: false }) { … }
```
The defaults object is the single source of truth — its keys/types *are* the element's typed props, so a typo or rename fails to compile, and props get sensible defaults. No string list, no `declare`.

> Note: standard `@reactive accessor` decorators would be the idiomatic fix, but Vite 8's Oxc transform ships the `accessor` keyword **un-lowered** (it lowers the decorator call but not the auto-accessor), and browsers reject `accessor` syntax. The mixin gives the same type-safety as plain ES2022 the toolchain handles correctly. Details in the commit message.

**Killed the remaining `any`s in `map-view`** — typed the two MediaWiki API responses and guard access with optional chaining (`data.query?.pages?.[id]?.images`), so a malformed payload returns cleanly instead of throwing into the catch.

**Smaller hardenings**
- `loadFavorites` validates to `string[]` rather than trusting `JSON.parse` (a non-array in storage no longer risks a `new Set()` throw).
- `map-view`'s `#emit` is constrained to the two events it sends.
- `MARKER_BASE` marked `satisfies L.CircleMarkerOptions` (typos in option names now fail to compile).
- The `favorite-toggle` emit is guarded so it can never send an `undefined` site.

## Verification
- `tsc` (strict) and `npm run build` both clean
- Bundle contains no raw `accessor`/decorator syntax (browser-safe ES2022)
- Browser smoke test: all reactive props re-render correctly (incl. the navbar `open` → `data-open` reflection), 4 Wikipedia thumbnails still load, no console errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)
