### PR TITLE
Add CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: npm

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,35 @@
+name: CI
+
+# Type-check and build on every pull request (and on master) so regressions are
+# caught before they merge. Deployment is handled separately by deploy.yml.
+on:
+  push:
+    branches: [master]
+  pull_request:
+
+permissions:
+  contents: read
+
+# Cancel superseded runs on the same branch/PR (e.g. when new commits are pushed).
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - run: npm ci
+
+      - name: Type-check
+        run: npm run typecheck
+
+      - name: Build
+        run: npm run build

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: npm

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # oldtown-map
 
+[![CI](https://github.com/bushidocodes/oldtown-map/actions/workflows/ci.yml/badge.svg)](https://github.com/bushidocodes/oldtown-map/actions/workflows/ci.yml)
+
 oldtown-map renders historic locations in Old Town Alexandria, Virginia on an
 interactive map as markers. It provides a sidebar with a searchable, filterable
 list of these locations. Selecting a marker or a list entry opens a popup with
@@ -44,6 +46,12 @@ Other scripts:
 * `npm run build` — type-check (`tsc`) and produce a bundled, minified build in `dist/`
 * `npm run preview` — serve the contents of `dist/` locally to preview the build
 * `npm run typecheck` — run the TypeScript type-checker only
+
+## Continuous integration
+
+[`.github/workflows/ci.yml`](.github/workflows/ci.yml) type-checks and builds the
+app on every pull request and on pushes to `master`, so regressions are caught
+before they ship. Deployment (below) is a separate workflow.
 
 ## Deployment
 


### PR DESCRIPTION
Adds a CI workflow so pull requests are verified before merge. Until now the only workflow was [`deploy.yml`](.github/workflows/deploy.yml), which runs *only* on pushes to `master` — meaning **PRs ran no automated checks at all**.

## What it does

[`.github/workflows/ci.yml`](.github/workflows/ci.yml) runs on every pull request and on pushes to `master`:

1. `npm ci`
2. `npm run typecheck` (`tsc`)
3. `npm run build` (`tsc && vite build`)

It mirrors the Node version (22) and action versions used by `deploy.yml`, so it's the same toolchain that's already green on master. Extras: `permissions: contents: read` (least privilege) and `concurrency` with `cancel-in-progress` so new pushes cancel superseded runs.

Type-check and build are separate steps so a type error vs. a bundler error is obvious at a glance. There are no tests or linter in the repo yet, so those aren't part of CI; easy to add later if/when they exist.

## Also
- README: a CI status badge under the title and a short **Continuous integration** section.
- Bumped `actions/setup-node@v4` → `@v6` in **both** ci.yml and deploy.yml. v4 bundles the Node 20 runtime that GitHub has deprecated on runners (the first CI run flagged it); v6 targets Node 24. `node-version`/`cache` are set explicitly, so it's a drop-in bump, applied to both files to keep them consistent.

## Verification
- Both CI runs on this PR are **green** (~13s); after the setup-node bump the Node 20 deprecation annotation is gone.
- The three commands were already proven green by `deploy.yml` on master.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
