### PR TITLE
chore: add .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,15 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_style = space
+indent_size = 2
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.md]
+trim_trailing_whitespace = false
+
+[Makefile]
+indent_style = tab


### PR DESCRIPTION
## Summary
Add portfolio hygiene files: **.editorconfig**.

## Details
- `.editorconfig` — charset, EOL, indent, trailing whitespace (language-tuned)


## Why
Aligns with gold-standard repos (e.g. `chord-grpc`, `keypunch`, `wasm-wasi-overview`) so editors and git stay consistent across the portfolio.